### PR TITLE
Refactor modals

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -8,3 +8,32 @@ body {
 .sidebar {
   background-color: #595959;
 }
+
+.custom-modal {
+  display: block;
+  z-index: 1006;
+  padding: 1rem;
+  border: 1px solid #cacaca;
+  background-color: #fefefe;
+  border-radius: 0;
+  position: relative;
+  top: 100px;
+  width: 600px;
+  max-width: 75rem;
+  min-height: 0;
+  margin-left: auto;
+  margin-right: auto;
+  overflow-y: auto;
+}
+
+.custom-modal-overlay {
+  display: block;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1005;
+  background-color: rgba(10, 10, 10, 0.45);
+  overflow-y: scroll;
+}

--- a/react/src/components/Dashboard.js
+++ b/react/src/components/Dashboard.js
@@ -15,13 +15,16 @@ class Dashboard extends Component {
     this.state = {
       currentUser: null,
       hasTasks: true,
-      newMonth: false
+      newMonth: false,
+      walkthroughStep: null
     }
 
     this.getUserData = this.getUserData.bind(this);
+    this.changeWalkthroughStep = this.changeWalkthroughStep.bind(this);
   }
 
-  getUserData() {
+  getUserData(checkForWalkthrough) {
+    checkForWalkthrough = (typeof checkForWalkthrough !== 'undefined') ? checkForWalkthrough : true;
     fetch(`/api/v1/users/fetch_current_user`, {
       credentials: 'same-origin'
     })
@@ -37,15 +40,32 @@ class Dashboard extends Component {
     .then(response => response.json())
     .then(body => {
       let newCurrentUser = body.user;
-      let newHasTasks = body.hasTasks;
-      let newNewMonth = body.newMonth
-      this.setState({
-        currentUser: newCurrentUser,
-        hasTasks: newHasTasks,
-        newMonth: newNewMonth
-      })
+      this.setState({ currentUser: newCurrentUser });
+      return body;
+    })
+    .then((body) => {
+      if (checkForWalkthrough) {
+        let newHasTasks = body.hasTasks;
+        let newNewMonth = body.newMonth;
+        let newWalkthroughStep = null;
+        if (!newHasTasks) {
+          newWalkthroughStep = "Welcome";
+        } else if (newNewMonth) {
+          newWalkthroughStep = "Summary";
+        }
+        this.setState({
+          hasTasks: newHasTasks,
+          newMonth: newNewMonth,
+          walkthroughStep: newWalkthroughStep
+        });
+      }
     })
     .catch(error => console.error(`Error in fetch: ${error.message}`));
+  }
+
+  changeWalkthroughStep(newStep) {
+    let newWalkthroughStep = newStep;
+    this.setState({ walkthroughStep: newWalkthroughStep });
   }
 
   componentDidMount() {
@@ -53,12 +73,43 @@ class Dashboard extends Component {
   }
 
   render() {
-    if (!this.state.hasTasks) {
-      $('#welcome').foundation('open');
+    let walkthroughContent;
+    let getUserData = () => {
+      this.getUserData(false);
     }
-
-    if (this.state.newMonth) {
-      $('#summary').foundation('open');
+    switch(this.state.walkthroughStep) {
+      case "Welcome":
+        walkthroughContent = < Welcome
+          changeWalkthroughStep = { this.changeWalkthroughStep }
+        />
+        break;
+      case "Summary":
+        walkthroughContent = < Summary
+          currentUser = { this.state.currentUser }
+          getUserData = { getUserData }
+        />
+        break;
+      case "Prep":
+        walkthroughContent = < Prep
+          currentUser = { this.state.currentUser }
+          getUserData = { getUserData }
+        />
+        break;
+      case "Trim":
+       walkthroughContent = < Trim />
+       break;
+      case "AddTasks":
+        walkthroughContent = < AddTasks
+          changeWalkthroughStep = { this.changeWalkthroughStep }
+        />
+        break;
+      case "MonthlyGoal":
+        walkthroughContent = < MonthlyGoal
+          changeWalkthroughStep = { this.changeWalkthroughStep }
+          currentUser = { this.state.currentUser }
+          getUserData = { getUserData }
+        />
+        break;
     }
 
     return(
@@ -67,8 +118,7 @@ class Dashboard extends Component {
         < Goals
           currentUser = { this.state.currentUser }
         />
-        < Welcome />
-
+        {walkthroughContent}
         < TaskList
           currentUser = { this.state.currentUser }
           getUserData = { this.getUserData }

--- a/react/src/components/Dashboard.js
+++ b/react/src/components/Dashboard.js
@@ -53,6 +53,7 @@ class Dashboard extends Component {
         } else if (newNewMonth) {
           newWalkthroughStep = "Summary";
         }
+        newWalkthroughStep = "Summary";
         this.setState({
           hasTasks: newHasTasks,
           newMonth: newNewMonth,
@@ -85,18 +86,22 @@ class Dashboard extends Component {
         break;
       case "Summary":
         walkthroughContent = < Summary
+          changeWalkthroughStep = { this.changeWalkthroughStep }
           currentUser = { this.state.currentUser }
           getUserData = { getUserData }
         />
         break;
       case "Prep":
         walkthroughContent = < Prep
+          changeWalkthroughStep = { this.changeWalkthroughStep }
           currentUser = { this.state.currentUser }
           getUserData = { getUserData }
         />
         break;
       case "Trim":
-       walkthroughContent = < Trim />
+       walkthroughContent = < Trim
+        changeWalkthroughStep = { this.changeWalkthroughStep }
+       />
        break;
       case "AddTasks":
         walkthroughContent = < AddTasks

--- a/react/src/components/Dashboard.js
+++ b/react/src/components/Dashboard.js
@@ -68,20 +68,7 @@ class Dashboard extends Component {
           currentUser = { this.state.currentUser }
         />
         < Welcome />
-        < Summary
-          currentUser = { this.state.currentUser }
-          getUserData = { this.getUserData }
-        />
-        < Prep
-          currentUser = { this.state.currentUser }
-          getUserData = { this.getUserData }
-        />
-        < Trim />
-        < AddTasks />
-        < MonthlyGoal
-          currentUser = { this.state.currentUser }
-          getUserData = { this.getUserData }
-        />
+
         < TaskList
           currentUser = { this.state.currentUser }
           getUserData = { this.getUserData }

--- a/react/src/components/MonthlyPrep/AddTasks.js
+++ b/react/src/components/MonthlyPrep/AddTasks.js
@@ -5,8 +5,7 @@ import TaskFormButton from '../TaskForm/TaskFormButton';
 
 const AddTasks = props => {
   let goToMonthlyGoal = () => {
-    $('#add-tasks').foundation('close');
-    $('#monthly-goal').foundation('open');
+    props.changeWalkthroughStep("MonthlyGoal");
   }
 
   let doneButton = < TaskFormButton
@@ -16,14 +15,15 @@ const AddTasks = props => {
   />
 
   return(
-    < TaskForm
-      subheader = "Add some things you would like to do this month"
-      closeOnSubmit = { false }
-      buttons = { doneButton }
-      closeOnClick = { false }
-      closeOnEsc = { false }
-      id = "add-tasks"
-    />
+    <div className="custom-modal-overlay">
+      < TaskForm
+        subheader = "Add some things you would like to do this month"
+        closeOnSubmit = { false }
+        buttons = { doneButton }
+        closeOnClick = { false }
+        id = "add-tasks"
+      />
+    </div>
   )
 }
 

--- a/react/src/components/MonthlyPrep/MonthlyGoal.js
+++ b/react/src/components/MonthlyPrep/MonthlyGoal.js
@@ -4,7 +4,7 @@ import TaskFormButton from '../TaskForm/TaskFormButton';
 
 const MonthlyGoal = props => {
   let goToDashboard = () => {
-    $('#monthly-goal').foundation('close');
+    props.changeWalkthroughStep(null);
   }
 
   let currentGoal, doneButton;
@@ -23,22 +23,21 @@ const MonthlyGoal = props => {
   }
 
   return(
-    <div
-      className="reveal"
-      id="monthly-goal"
-      data-reveal
-      data-close-on-click="false"
-      data-close-on-esc="false"
-    >
-      <h1>{"Calculate Goal"}</h1>
-      <p>{"Now let's calculate your points goal for this month"}</p>
-      <br></br>
-      {currentGoal}
-      < CalculateGoalButton
-        currentUser = { props.currentUser }
-        getUserData = { props.getUserData }
-      />
-      {doneButton}
+    <div className="custom-modal-overlay">
+      <div
+        className="callout custom-modal"
+        id="monthly-goal"
+      >
+        <h1>{"Calculate Goal"}</h1>
+        <p>{"Now let's calculate your points goal for this month"}</p>
+        <br></br>
+        {currentGoal}
+        < CalculateGoalButton
+          currentUser = { props.currentUser }
+          getUserData = { props.getUserData }
+        />
+        {doneButton}
+      </div>
     </div>
   )
 }

--- a/react/src/components/MonthlyPrep/Prep.js
+++ b/react/src/components/MonthlyPrep/Prep.js
@@ -3,8 +3,7 @@ import TaskFormButton from '../TaskForm/TaskFormButton';
 
 const Prep = props => {
   let goToTrim = () => {
-    $('#prep').foundation('close');
-    $('#trim').foundation('open');
+    props.changeWalkthroughStep("Trim");
   }
 
   let clearTasks = () => {
@@ -22,34 +21,30 @@ const Prep = props => {
           throw(error);
         }
       })
-      .then(() => {
-        $('#prep').foundation('close');
-        $('#add-tasks').foundation('open');
-      })
+      .then(() => { props.changeWalkthroughStep("AddTasks"); })
       .catch(error => console.error(`Error in fetch: ${error.message}`));
   }
 
   return(
-    <div
-      className="reveal"
-      id="prep"
-      data-reveal
-      data-close-on-click="false"
-      data-close-on-esc="false"
-    >
-      <h1>{"Would you like to import last month's tasks?"}</h1>
-      <p>{"You will be able to add or remove tasks after importing"}</p>
-      <div>
-        < TaskFormButton
-          className = "button"
-          buttonText = "Yes"
-          onClick = { goToTrim }
-        />
-        < TaskFormButton
-          className = "alert button"
-          buttonText = "No"
-          onClick = { clearTasks }
-        />
+    <div className="custom-modal-overlay">
+      <div
+        className="callout custom-modal"
+        id="prep"
+      >
+        <h1>{"Would you like to import last month's tasks?"}</h1>
+        <p>{"You will be able to add or remove tasks after importing"}</p>
+        <div>
+          < TaskFormButton
+            className = "button"
+            buttonText = "Yes"
+            onClick = { goToTrim }
+          />
+          < TaskFormButton
+            className = "alert button"
+            buttonText = "No"
+            onClick = { clearTasks }
+          />
+        </div>
       </div>
     </div>
   )

--- a/react/src/components/MonthlyPrep/Summary.js
+++ b/react/src/components/MonthlyPrep/Summary.js
@@ -23,11 +23,8 @@ const Summary = props => {
           throw(error);
         }
       })
-      .then(() => { props.getUserData() })
-      .then(() => {
-        $('#summary').foundation('close');
-        $('#prep').foundation('open');
-      })
+      .then(() => { props.getUserData(false); })
+      .then(() => { props.changeWalkthroughStep("Prep"); })
       .catch(error => console.error(`Error in fetch: ${error.message}`));
   }
 
@@ -44,24 +41,23 @@ const Summary = props => {
       <p>{"You met your points goal last month!"}</p>
     </div>
   } else {
-    <p>{"You didn't quite meet your goal this month. But that's okay!"}</p>
+    body = <p>{"You didn't quite meet your goal this month. But that's okay!"}</p>
   }
 
   return(
-    <div
-      className="reveal"
-      id="summary"
-      data-reveal
-      data-close-on-click="false"
-      data-close-on-esc="false"
-    >
-      {body}
-      <p>{"Let's get set up for next month."}</p>
-      < TaskFormButton
-        className = "button float-right"
-        buttonText = "Continue"
-        onClick = { goToPrep }
-      />
+    <div className="custom-modal-overlay">
+      <div
+        className="callout custom-modal"
+        id="summary"
+      >
+        {body}
+        <p>{"Let's get set up for next month."}</p>
+        < TaskFormButton
+          className = "button float-right"
+          buttonText = "Continue"
+          onClick = { goToPrep }
+        />
+      </div>
     </div>
   )
 }

--- a/react/src/components/MonthlyPrep/Trim.js
+++ b/react/src/components/MonthlyPrep/Trim.js
@@ -1,30 +1,125 @@
-import React from 'react';
-import TrimTaskListContainer from './TrimTaskListContainer';
+import React, { Component } from 'react';
 import TaskFormButton from '../TaskForm/TaskFormButton';
+import TaskForm from '../TaskForm/TaskForm';
+import TrimTask from './TrimTask';
 
-const Trim = props => {
-  let goToAddTasks = () => {
-    $('#trim').foundation('close');
-    $('#add-tasks').foundation('open');
+class Trim extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      tasks: [],
+      selectedTaskId: null,
+      showForm: false
+    }
+
+    this.goToAddTasks = this.goToAddTasks.bind(this);
+    this.handleFormClick = this.handleFormClick.bind(this);
+    this.handleCloseForm = this.handleCloseForm.bind(this);
+    this.getTasks = this.getTasks.bind(this);
+    this.findSelectedTask = this.findSelectedTask.bind(this);
   }
 
-  return(
-    <div
-      className="reveal"
-      id="trim"
-      data-reveal
-      data-close-on-click="false"
-      data-close-on-esc="false"
-    >
-      <h1>{"Edit or Remove Tasks"}</h1>
-      < TrimTaskListContainer />
-      < TaskFormButton
-        className = "button float-right"
-        onClick = { goToAddTasks }
-        buttonText = "Done"
+  goToAddTasks() {
+    this.props.changeWalkthroughStep("AddTasks");
+  }
+
+  handleFormClick(id) {
+    let newSelectedTaskId = id;
+    let newShowForm = true;
+    this.setState({
+      selectedTaskId: newSelectedTaskId,
+      showForm: newShowForm
+    });
+  }
+
+  handleCloseForm() {
+    let newSelectedTaskId = null;
+    let newShowForm = false;
+    this.setState({
+      selectedTaskId: newSelectedTaskId,
+      showForm: newShowForm
+    });
+  }
+
+  getTasks() {
+    fetch('/api/v1/tasks', {
+      credentials: 'same-origin'
+    })
+      .then(response => {
+        if (response.ok) {
+          return response;
+        } else {
+          let errorMessage = `${response.status}, (${response.statusText})`;
+          let error = new Error(errorMessage);
+          throw(error);
+        }
+      })
+      .then(response => response.json())
+      .then(body => {
+        let newTasks = body.tasks;
+        this.setState({
+          tasks: newTasks,
+        })
+      })
+      .catch(error => console.error(`Error in fetch: ${error.message}`));
+  }
+
+  componentDidMount() {
+    this.getTasks();
+  }
+
+  findSelectedTask() {
+    for (let task of this.state.tasks) {
+      if (task.id === this.state.selectedTaskId) {
+        return(task);
+      }
+    }
+    return(null);
+  }
+
+  render() {
+    let tasks, form, content;
+    let selectedTask = this.findSelectedTask();
+    if (this.state.showForm) {
+      form = < TaskForm
+        id = "edit-task-form"
+        getTasks = { this.getTasks }
+        selectedTask = { selectedTask }
+        closeOnSubmit = { true }
+        closeOnClick = { false }
+        handleCloseForm = { this.handleCloseForm }
       />
-    </div>
-  )
+      content = form
+    } else {
+      tasks = this.state.tasks.map((task) => {
+        let handleFormClick = () => {
+          this.handleFormClick(task.id);
+        }
+        return(
+          < TrimTask
+            key = { task.id }
+            name = { task.name }
+            handleFormClick = { handleFormClick }
+          />
+        )
+      });
+      content = <div className="callout custom-modal" id="trim">
+        <h1>{"Edit or Remove Tasks"}</h1>
+        {tasks}
+        < TaskFormButton
+          className = "button float-right"
+          onClick = { this.goToAddTasks }
+          buttonText = "Done"
+        />
+      </div>
+    }
+
+    return(
+      <div className="custom-modal-overlay">
+        {content}
+      </div>
+    )
+  }
 }
 
 export default Trim;

--- a/react/src/components/MonthlyPrep/TrimTask.js
+++ b/react/src/components/MonthlyPrep/TrimTask.js
@@ -8,7 +8,6 @@ const TrimTask = props => {
         <button
           className="button float-right"
           onClick={props.handleFormClick}
-          data-open="edit-task-form"
         >
           <i className="fa fa-pencil-square-o" aria-hidden="true"></i>
         </button>

--- a/react/src/components/MonthlyPrep/TrimTaskListContainer.js
+++ b/react/src/components/MonthlyPrep/TrimTaskListContainer.js
@@ -7,17 +7,28 @@ class TrimTaskListContainer extends Component {
     super(props)
     this.state = {
       tasks: [],
-      selectedTaskId: null
+      selectedTaskId: null,
+      showForm: false
     }
 
     this.handleFormClick = this.handleFormClick.bind(this);
+    this.handleCloseForm = this.handleCloseForm.bind(this);
     this.getTasks = this.getTasks.bind(this);
     this.findSelectedTask = this.findSelectedTask.bind(this);
   }
 
   handleFormClick(id) {
     let newSelectedTaskId = id;
-    this.setState({ selectedTaskId: newSelectedTaskId });
+    let newShowForm = true;
+    this.setState({
+      selectedTaskId: newSelectedTaskId,
+      showForm: newShowForm
+    });
+  }
+
+  handleCloseForm() {
+    let newShowForm = false;
+    this.setState({ showForm: newShowForm });
   }
 
   getTasks() {
@@ -57,33 +68,37 @@ class TrimTaskListContainer extends Component {
   }
 
   render() {
-    let tasks = this.state.tasks.map((task) => {
-      let handleFormClick = () => {
-        this.handleFormClick(task.id);
-      }
-      return(
-        < TrimTask
-          key = { task.id }
-          name = { task.name }
-          handleFormClick = { handleFormClick }
-        />
-      )
-    });
-
+    let tasks;
     let selectedTask = this.findSelectedTask();
+    let form;
+    if (this.state.showForm) {
+      form = < TaskForm
+        id = "edit-task-form"
+        getTasks = { this.getTasks }
+        selectedTask = { selectedTask }
+        closeOnSubmit = { true }
+        closeOnClick = { false }
+      />
+    } else {
+      tasks = this.state.tasks.map((task) => {
+        let handleFormClick = () => {
+          this.handleFormClick(task.id);
+        }
+        return(
+          < TrimTask
+            key = { task.id }
+            name = { task.name }
+            handleFormClick = { handleFormClick }
+          />
+        )
+      });
+      tasks = <div className="callout custom-modal">{tasks}</div>
+    }
 
     return(
-      <div>
+      <div className="custom-modal-overlay">
         {tasks}
-        < TaskForm
-          id = "edit-task-form"
-          getTasks = { this.getTasks }
-          selectedTask = { selectedTask }
-          closeOnSubmit = { false }
-          closeOnClick = { false }
-          closeOnEsc = { false }
-          returnToPrep = { true }
-        />
+        {form}
       </div>
     )
   }

--- a/react/src/components/MonthlyPrep/Welcome.js
+++ b/react/src/components/MonthlyPrep/Welcome.js
@@ -3,25 +3,23 @@ import TaskFormButton from '../TaskForm/TaskFormButton';
 
 const Welcome = props => {
   let goToAddTasks = () => {
-    $('#welcome').foundation('close');
-    $('#add-tasks').foundation('open');
+    props.changeWalkthroughStep("AddTasks");
   }
 
   return(
-    <div
-      className="reveal"
-      id="welcome"
-      data-reveal
-      data-close-on-click="false"
-      data-close-on-esc="false"
-    >
-      <h1>{"Welcome to BeBetter!"}</h1>
-      <p>{"It looks like you don't have any tasks for this month. Let's get started!"}</p>
-      < TaskFormButton
-        className = "button float-right"
-        buttonText = "Continue"
-        onClick = { goToAddTasks }
-      />
+    <div className="custom-modal-overlay">
+      <div
+        className="callout custom-modal"
+        id="welcome"
+      >
+        <h1>{"Welcome to BeBetter!"}</h1>
+        <p>{"It looks like you don't have any tasks for this month. Let's get started!"}</p>
+        < TaskFormButton
+          className = "button float-right"
+          buttonText = "Continue"
+          onClick = { goToAddTasks }
+        />
+      </div>
     </div>
   )
 }

--- a/react/src/components/Task.js
+++ b/react/src/components/Task.js
@@ -50,7 +50,7 @@ class Task extends Component {
           <div className="small-8 columns">
             <p>{ this.props.name }</p>
             <p>{ howOften }</p>
-            <button className="button" onClick={this.props.handleFormClick} data-open="new-task-form">
+            <button className="button" onClick={this.props.handleFormClick}>
               <i className="fa fa-pencil-square-o" aria-hidden="true"></i>
             </button>
           </div>

--- a/react/src/components/TaskForm/TaskForm.js
+++ b/react/src/components/TaskForm/TaskForm.js
@@ -92,19 +92,18 @@ class TaskForm extends Component {
         }
       })
       .then(() => {
-        this.setState({
-          formHeader: "Add a New Task",
-          formButtonText: "Submit",
-          formFields: this.defaultFormFields()
-        });
-      })
-      .then(() => {
         if (this.props.closeOnSubmit) {
           this.props.handleCloseForm();
           this.props.getTasks();
+        } else {
+          let newErrors = [];
+          this.setState({
+            formHeader: "Add a New Task",
+            formButtonText: "Submit",
+            formFields: this.defaultFormFields(),
+            errors: newErrors
+          });
         }
-        let newErrors = [];
-        this.setState({ errors: newErrors });
       })
       .catch(error => console.error(`Error in fetch: ${error.message}`));
   }

--- a/react/src/components/TaskForm/TaskForm.js
+++ b/react/src/components/TaskForm/TaskForm.js
@@ -102,8 +102,6 @@ class TaskForm extends Component {
         if (this.props.closeOnSubmit) {
           this.props.handleCloseForm();
           this.props.getTasks();
-        } else if (this.props.returnToPrep) {
-          $('#trim').foundation('open');
         }
         let newErrors = [];
         this.setState({ errors: newErrors });

--- a/react/src/components/TaskForm/TaskForm.js
+++ b/react/src/components/TaskForm/TaskForm.js
@@ -30,7 +30,6 @@ class TaskForm extends Component {
 
   componentDidMount() {
     let editTask = this.props.selectedTask;
-    debugger;
     let newFormHeader = "Add a New Task";
     let newFormButtonText = "Submit";
     let newFormFields = this.defaultFormFields();
@@ -176,31 +175,29 @@ class TaskForm extends Component {
     }
 
     return(
-      <div className="custom-modal-overlay">
-        <div className="callout custom-modal"
-          id={this.props.id}
-          data-reveal
-          data-close-on-click={this.props.closeOnClick}
-          data-close-on-esc={this.props.closeOnEsc}
-        >
-          < TaskFormHeader
-            formHeader = { this.state.formHeader }
-            subheader = { this.props.subheader }
-          />
-          < TaskFormFieldsContainer
-            onChange = { this.onChange }
-            formFields = { this.state.formFields }
-            importances = { this.props.importances }
-            periods = { this.props.periods }
-            selectedTask = { this.props.selectedTask }
-            handleSubmit = { this.handleSubmit }
-            handleDelete = { this.handleDelete }
-            formButtonText = { this.state.formButtonText }
-            buttons = { this.props.buttons }
-          />
-          {closeButton}
-          {errors}
-        </div>
+      <div className="callout custom-modal"
+        id={this.props.id}
+        data-reveal
+        data-close-on-click={this.props.closeOnClick}
+        data-close-on-esc={this.props.closeOnEsc}
+      >
+        < TaskFormHeader
+          formHeader = { this.state.formHeader }
+          subheader = { this.props.subheader }
+        />
+        < TaskFormFieldsContainer
+          onChange = { this.onChange }
+          formFields = { this.state.formFields }
+          importances = { this.props.importances }
+          periods = { this.props.periods }
+          selectedTask = { this.props.selectedTask }
+          handleSubmit = { this.handleSubmit }
+          handleDelete = { this.handleDelete }
+          formButtonText = { this.state.formButtonText }
+          buttons = { this.props.buttons }
+        />
+        {closeButton}
+        {errors}
       </div>
     )
   }

--- a/react/src/components/TaskForm/TaskForm.js
+++ b/react/src/components/TaskForm/TaskForm.js
@@ -29,24 +29,20 @@ class TaskForm extends Component {
   }
 
   componentDidMount() {
-    let newFormFields = this.defaultFormFields();
-    this.setState({ formFields: newFormFields });
-  }
-
-  componentWillReceiveProps(newProps) {
-    let newTask = newProps.selectedTask;
+    let editTask = this.props.selectedTask;
+    debugger;
     let newFormHeader = "Add a New Task";
     let newFormButtonText = "Submit";
     let newFormFields = this.defaultFormFields();
-    if (newTask) {
+    if (editTask) {
       newFormHeader = "Edit Task";
       newFormButtonText = "Edit";
       newFormFields = {
-        taskName: newTask.name,
-        taskImportance: newTask.importance,
-        taskValue: newTask.value,
-        taskReps: newTask.reps,
-        taskPeriod: newTask.period
+        taskName: editTask.name,
+        taskImportance: editTask.importance,
+        taskValue: editTask.value,
+        taskReps: editTask.reps,
+        taskPeriod: editTask.period
       }
     }
     this.setState({
@@ -105,7 +101,7 @@ class TaskForm extends Component {
       })
       .then(() => {
         if (this.props.closeOnSubmit) {
-          $('#new-task-form').foundation('close');
+          this.props.handleCloseForm();
           this.props.getTasks();
         } else if (this.props.returnToPrep) {
           $('#trim').foundation('open');
@@ -174,35 +170,37 @@ class TaskForm extends Component {
 
     let closeButton;
     if (this.props.closeOnClick) {
-      closeButton = <button className="close-button" data-close="new-task-form">
+      closeButton = <button className="close-button" onClick={this.props.handleCloseForm}>
         <span aria-hidden="true">&times;</span>
       </button>
     }
 
     return(
-      <div className="reveal"
-        id={this.props.id}
-        data-reveal
-        data-close-on-click={this.props.closeOnClick}
-        data-close-on-esc={this.props.closeOnEsc}
-      >
-        < TaskFormHeader
-          formHeader = { this.state.formHeader }
-          subheader = { this.props.subheader }
-        />
-        < TaskFormFieldsContainer
-          onChange = { this.onChange }
-          formFields = { this.state.formFields }
-          importances = { this.props.importances }
-          periods = { this.props.periods }
-          selectedTask = { this.props.selectedTask }
-          handleSubmit = { this.handleSubmit }
-          handleDelete = { this.handleDelete }
-          formButtonText = { this.state.formButtonText }
-          buttons = { this.props.buttons }
-        />
-        {closeButton}
-        {errors}
+      <div className="custom-modal-overlay">
+        <div className="callout custom-modal"
+          id={this.props.id}
+          data-reveal
+          data-close-on-click={this.props.closeOnClick}
+          data-close-on-esc={this.props.closeOnEsc}
+        >
+          < TaskFormHeader
+            formHeader = { this.state.formHeader }
+            subheader = { this.props.subheader }
+          />
+          < TaskFormFieldsContainer
+            onChange = { this.onChange }
+            formFields = { this.state.formFields }
+            importances = { this.props.importances }
+            periods = { this.props.periods }
+            selectedTask = { this.props.selectedTask }
+            handleSubmit = { this.handleSubmit }
+            handleDelete = { this.handleDelete }
+            formButtonText = { this.state.formButtonText }
+            buttons = { this.props.buttons }
+          />
+          {closeButton}
+          {errors}
+        </div>
       </div>
     )
   }

--- a/react/src/components/TaskList.js
+++ b/react/src/components/TaskList.js
@@ -8,17 +8,28 @@ class TaskList extends Component {
     super(props)
     this.state = {
       tasks: [],
-      selectedTaskId: null
+      selectedTaskId: null,
+      showForm: false
     }
 
     this.handleFormClick = this.handleFormClick.bind(this);
+    this.handleCloseForm = this.handleCloseForm.bind(this);
     this.getTasks = this.getTasks.bind(this);
     this.findSelectedTask = this.findSelectedTask.bind(this);
   }
 
   handleFormClick(id) {
     let newSelectedTaskId = id;
-    this.setState({ selectedTaskId: newSelectedTaskId });
+    let newShowForm = true;
+    this.setState({
+      selectedTaskId: newSelectedTaskId,
+      showForm: newShowForm
+    });
+  }
+
+  handleCloseForm() {
+    let newShowForm = false;
+    this.setState({ showForm: newShowForm });
   }
 
   getTasks() {
@@ -87,6 +98,18 @@ class TaskList extends Component {
 
     let selectedTask = this.findSelectedTask();
 
+    let form;
+    if (this.state.showForm) {
+      form = < TaskForm
+        id = "new-task-form"
+        getTasks = { this.getTasks }
+        selectedTask = { selectedTask }
+        closeOnSubmit = { true }
+        closeOnClick = { true }
+        handleCloseForm = { this.handleCloseForm }
+      />
+    }
+
     return(
       <div className="small-10 columns">
         < TaskListHeader
@@ -95,14 +118,7 @@ class TaskList extends Component {
           currentUser = { this.props.currentUser }
           getUserData = { this.props.getUserData }
         />
-        < TaskForm
-          id = "new-task-form"
-          getTasks = { this.getTasks }
-          selectedTask = { selectedTask }
-          closeOnSubmit = { true }
-          closeOnClick = { true }
-          closeOnEsc = { true }
-        />
+        { form }
         { tasks }
       </div>
     )

--- a/react/src/components/TaskList.js
+++ b/react/src/components/TaskList.js
@@ -100,14 +100,16 @@ class TaskList extends Component {
 
     let form;
     if (this.state.showForm) {
-      form = < TaskForm
-        id = "new-task-form"
-        getTasks = { this.getTasks }
-        selectedTask = { selectedTask }
-        closeOnSubmit = { true }
-        closeOnClick = { true }
-        handleCloseForm = { this.handleCloseForm }
-      />
+      form = <div className="custom-modal-overlay">
+        < TaskForm
+          id = "new-task-form"
+          getTasks = { this.getTasks }
+          selectedTask = { selectedTask }
+          closeOnSubmit = { true }
+          closeOnClick = { true }
+          handleCloseForm = { this.handleCloseForm }
+        />
+      </div>
     }
 
     return(

--- a/react/src/components/TaskListHeader.js
+++ b/react/src/components/TaskListHeader.js
@@ -13,7 +13,6 @@ class TaskListHeader extends Component {
         <div className="small-2 text-right columns">
           <button
             className="button"
-            data-open="new-task-form"
             onClick={this.props.handleNewFormClick}
           >
             <i className="fa fa-plus-square" aria-hidden="true"></i>


### PR DESCRIPTION
Refactored all pop-up forms and messages to be custom classes instead of Foundation modals. This was done because Foundation modals use javascript to operate and this was (presumably) causing issues when trying to dynamically display them in React. I took the CSS from the `reveal` styles in Foundation, and put them into a custom class. The function is essentially the same, but the pop-up occurs when the React component is mounted, instead of when a jQuery call is made to a DOM Element.